### PR TITLE
feat(INT-430): Add option to send screenshots from server as base64

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ This option allows you to specify a regex to used to ignore domains.  Any domain
 
 This option allows you to specify a regex used to ignore IPv4 Addresses.  Any IPv4 matching the regex will not be searched.
 
+### Proxy Screenshots through Polarity Server
+
+If checked, the Overlay Window will receive the URL\'s screenshot from the Polarity server rather than directly from the urlscan website. If your screenshot images are not properly displaying try enabling this option as it can resolve issues in some environments with unsupported web proxy configurations on the client.
+
 ## Installation Instructions
 
 Installation instructions for integrations are provided on the [PolarityIO GitHub Page](https://polarityio.github.io/).

--- a/config/config.js
+++ b/config/config.js
@@ -146,7 +146,7 @@ module.exports = {
     },
     {
       key: 'downloadScreenshot',
-      name: 'Proxy screenshots through Polarity Server',
+      name: 'Proxy Screenshots through Polarity Server',
       description:
         'If checked, the Overlay Window will receive the URL\'s screenshot from the Polarity server rather than directly from the urlscan website. If your screenshot images are not properly displaying try enabling this option as it can resolve issues in some environments with unsupported web proxy configurations on the client.',
       default: false,

--- a/config/config.js
+++ b/config/config.js
@@ -22,7 +22,8 @@ module.exports = {
    * @type String
    * @optional
    */
-  description: 'Searches the urlscan.io API and returns results from the most recent, relevant scan',
+  description:
+    'Searches the urlscan.io API and returns results from the most recent, relevant scan',
   entityTypes: ['IPv4', 'IPv6', 'IPv4CIDR', 'domain', 'url', 'sha256'],
   onDemandOnly: true,
   /**
@@ -128,8 +129,7 @@ module.exports = {
     {
       key: 'domainBlocklistRegex',
       name: 'Ignored Domain Regex',
-      description:
-        'Domains that match the given regex will not be looked up.',
+      description: 'Domains that match the given regex will not be looked up.',
       default: '',
       type: 'text',
       userCanEdit: false,
@@ -143,6 +143,16 @@ module.exports = {
       type: 'text',
       userCanEdit: false,
       adminOnly: false
+    },
+    {
+      key: 'downloadScreenshot',
+      name: 'Proxy screenshots through Polarity Server',
+      description:
+        'If checked, the Overlay Window will receive the URL\'s screenshot from the Polarity server rather than directly from the urlscan website. If your screenshot images are not properly displaying try enabling this option as it can resolve issues in some environments with unsupported web proxy configurations on the client.',
+      default: false,
+      type: 'boolean',
+      userCanEdit: false,
+      adminOnly: true
     }
   ]
 };

--- a/integration.js
+++ b/integration.js
@@ -119,9 +119,13 @@ async function getScreenshotAsBase64(imageUrl) {
         return reject(error);
       }
 
-      if (response.statusCode !== 200) {
+      if (
+        ![200, 404].includes(response.statusCode) &&
+        !(body && Buffer.from(body).toString('base64').length)
+      ) {
         return reject({
-          detail: 'Unexpected status code when downloading screenshot from urlscan',
+          detail:
+            'Unexpected status code or Image Not Found when downloading screenshot from urlscan',
           response
         });
       }
@@ -130,6 +134,7 @@ async function getScreenshotAsBase64(imageUrl) {
         response.headers['content-type'] +
         ';base64,' +
         Buffer.from(body).toString('base64');
+
       resolve(data);
     });
   });
@@ -171,7 +176,10 @@ function doLookup(entities, options, cb) {
               }
             },
             async function (result) {
-              if (options.downloadScreenshot) {
+              if (
+                options.downloadScreenshot &&
+                fp.get('body.results.0.screenshot', result)
+              ) {
                 const screenshot = await getScreenshotAsBase64(
                   result.body.results[0].screenshot
                 );

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "main": "./integration.js",
   "name": "urlscan",
-  "version": "3.2.6-beta",
+  "version": "3.3.0",
   "private": true,
   "dependencies": {
     "request": "^2.88.2",

--- a/templates/us-block.hbs
+++ b/templates/us-block.hbs
@@ -87,7 +87,11 @@
             <span class="p-title">{{fa-icon "browser" fixedWidth=true}} Screenshot</span>
             {{#if result._id}}
                 <div class="image-container">
-                    <img src="https://urlscan.io/screenshots/{{result._id}}.png">
+                    {{#if result.getScreenshotAsBase64}}
+                      <img src="{{result.getScreenshotAsBase64}}"/>
+                    {{else}}
+                      <img src="{{result.screenshot}}">
+                    {{/if}}
                 </div>
                 <div>
                     <span class="p-key">Screenshot URL: </span>


### PR DESCRIPTION
1. Formats `integration.js` with prettier (hence all the small space changes)
2. Adds new method to fetch a screenshot as a base64 encoded string
3. Returns the base 64 encoded screenshot on the payload if the new option is enabled
4. Displays either the base64 encoded screenshot if available or the normal screenshot url